### PR TITLE
Pandoc本家のURLを更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
   
   <h1 id="日本pandocユーザ会">日本Pandocユーザ会</h1>
-<p>この組織はドキュメント変換ツールPandoc (<a href="http://johnmacfarlane.net/pandoc/index.html">http://johnmacfarlane.net/pandoc/index.html</a>) の普及および情報共有を目的とした任意団体です。 （現在のところ非公式です。）</p>
+<p>この組織はドキュメント変換ツールPandoc (<a href="http://pandoc.org">http://pandoc.org</a>) の普及および情報共有を目的とした任意団体です。 （現在のところ非公式です。）</p>
 <p>現在は、ユーザーズガイドの日本語版、およびメーリングリストの紹介場所としています。</p>
 <p><a href="./users-guide/">Pandocユーザーズガイド 日本語版</a></p>
 <p>他の情報も随時載せていく予定です。 このサイトについてご意見・ご要望があれば、このサイト用の <a href="https://github.com/sky-y/site-pandoc-jp/issues">Issues</a>にご投稿くださるか、 @<a href="https://twitter.com/sky_y">sky_y</a>までご連絡ください。</p>


### PR DESCRIPTION
Pandoc本家サイトのURLがhttp://pandoc.orgに更新されています。